### PR TITLE
(#14) `--dump-db <path>` dumps to `<path>` instead to the `dumped.txt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- (#14) `--dump-db <path>` dumps to `<path>` instead to the `dumped.txt`
 
 ## [0.3.0] - 2020-11-26
 ### Added

--- a/src/30_phone_book.hpp
+++ b/src/30_phone_book.hpp
@@ -20,7 +20,7 @@ struct PhoneBook {
     int find_native_tongue_in_wikidata();
     int find_names_in_wikidata();
     int find_parents_in_wikidata();
-    void dump(std::string filepath);
+    void dump(aids::String_View);
 };
 
 PhoneBook parse(aids::String_View filepath);

--- a/src/80_phone_book.cpp
+++ b/src/80_phone_book.cpp
@@ -304,11 +304,17 @@ void PhoneBook::dump(aids::String_View filepath) {
     using aids::operator""_sv;
     const size_t size{filepath.count + 1};
     char *buf = (char*)malloc(filepath.count + 1);
+    assert(buf);
     defer(free(buf));
     memset(buf, 0, size);
     memcpy(buf, filepath.data, size);
-    
+
     FILE* file = fopen(buf, "w+");
+    if (nullptr == file) {
+        aids::println(stderr, "Failed to open file `", buf, "`: ", strerror(errno));
+        aids::println(stderr, "Database will not be dumped.");
+        return;
+    }
     defer(fclose(file));
     for (size_t i = 0; i < hashmap.capacity; ++i) {
         if (hashmap.buckets[i].has_value) {

--- a/src/80_phone_book.cpp
+++ b/src/80_phone_book.cpp
@@ -300,10 +300,16 @@ int PhoneBook::find_parents_in_wikidata() {
     return resps.size();
 }
 
-void PhoneBook::dump(std::string filepath) {
+void PhoneBook::dump(aids::String_View filepath) {
     using aids::operator""_sv;
-
-    FILE* file = fopen(filepath.c_str(), "w+");
+    const size_t size{filepath.count + 1};
+    char *buf = (char*)malloc(filepath.count + 1);
+    defer(free(buf));
+    memset(buf, 0, size);
+    memcpy(buf, filepath.data, size);
+    
+    FILE* file = fopen(buf, "w+");
+    defer(fclose(file));
     for (size_t i = 0; i < hashmap.capacity; ++i) {
         if (hashmap.buckets[i].has_value) {
             auto &key = hashmap.buckets[i].unwrap.key;
@@ -314,5 +320,4 @@ void PhoneBook::dump(std::string filepath) {
                     " : ", value.mother.has_value ? value.mother.unwrap.value : ""_sv);
         }
     }
-    fclose(file);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,9 +107,7 @@ int main(int argc, char *argv[]) {
     }
 
     if (database_output_filepath.has_value) {
-        println(stderr, "TODO(#14): PhoneBook::dump accepts only std::string. Database will be dumped to `dumped.txt` as a woraround");
-        // phoneBook.dump(database_output_filepath.unwrap);
-        phoneBook.dump("dumped.txt");
+        phoneBook.dump(database_output_filepath.unwrap);
     }
 
     phoneBook.print_origin_by_blood(initial_person_key);


### PR DESCRIPTION
Closes #14